### PR TITLE
Fix: 트레이닝 생성 에러 수정, 트레이닝 날짜 수정 시 불가능한 날짜 리스트 받도록 수정, 생성/수정 리다이렉트 변경

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,7 +40,7 @@ import DetailPost, {
 import Help from 'pages/help';
 
 // components
-import CreateTrainer, {
+import CreateTraining, {
   action as createTrainerAction,
   loader as createTrainerLoader,
 } from 'pages/trainer/create';
@@ -269,14 +269,9 @@ function App() {
         // 트레이너 생성
         {
           path: pageRoutes.trainer.new,
-          children: [
-            {
-              index: true,
-              element: <CreateTrainer />,
-              action: createTrainerAction,
-              loader: createTrainerLoader,
-            },
-          ],
+          element: <CreateTraining />,
+          action: createTrainerAction,
+          loader: createTrainerLoader,
         },
       ],
     },

--- a/src/components/calendar/Calendar.tsx
+++ b/src/components/calendar/Calendar.tsx
@@ -101,12 +101,15 @@ const Calendar: React.FC<CalendarProps> = ({
   };
 
   const isActiveDate = (dateString: string) => {
+    if (unavailabeDates) {
+      return !unavailabeDates?.some((d) => {
+        if (new Date() >= new Date(dateString)) return true;
+        return d === dateString;
+      });
+    }
     if (!availableDates) {
       const date = new Date();
       return new Date(dateString) >= date;
-    }
-    if (unavailabeDates) {
-      return unavailabeDates?.some((d) => d !== dateString);
     }
     return availableDates?.some((d) => d.date === dateString && d.enabled);
   };

--- a/src/pageRoutes.ts
+++ b/src/pageRoutes.ts
@@ -27,8 +27,7 @@ const userRoutes = {
 const trainerRoutes = {
   base: '/trainer',
   index: 'home',
-  new: 'new',
-  create: 'create',
+  new: 'newTraining',
 };
 
 const helpRoutes = {

--- a/src/pages/trainer/TrainerCalendarUpdateForm.tsx
+++ b/src/pages/trainer/TrainerCalendarUpdateForm.tsx
@@ -9,7 +9,10 @@ import FormLabel from '../../components/form/FormLabel';
 import FormError from '../../components/form/FormError';
 import { SelectedDates } from '../../redux/initialStates/initialStateTypes';
 import { TrainingDateReservationNumDto } from '../../types/swagger/model/trainingDateReservationNumDto';
-import { getTrainersReserveCount } from '../../apis/trainig';
+import {
+  getTrainersDateList,
+  getTrainersReserveCount,
+} from '../../apis/trainig';
 import Calendar from '../../components/calendar/Calendar';
 import MultipleDateInput from '../../components/calendar/MultipleDate';
 
@@ -18,6 +21,7 @@ const TrainerCalendarUpdateForm: React.FC<{ trainingId: number }> = ({
 }) => {
   const [trainingCalendarDto, setTrainingCalendarDto] =
     useState<TrainingDateReservationNumDto[]>();
+  const [selectUnabledDates, setSelectUnabledDates] = useState<string[]>();
   const errors = useActionData() as FormErrors;
 
   const dates = trainingCalendarDto?.map((training) => training.date);
@@ -46,10 +50,14 @@ const TrainerCalendarUpdateForm: React.FC<{ trainingId: number }> = ({
     const trainingFetch = async () => {
       try {
         const res = await getTrainersReserveCount(trainingId);
+        const dateList = await getTrainersDateList();
         if (res.status === 200) {
           setTrainingCalendarDto(res.data);
         } else {
           throw new Error(`server is trouble with${res.status}`);
+        }
+        if (dateList.status === 200) {
+          setSelectUnabledDates(dateList.data);
         }
       } catch (err) {
         const error = err as AxiosError<ErrorResponseDto>;
@@ -81,6 +89,7 @@ const TrainerCalendarUpdateForm: React.FC<{ trainingId: number }> = ({
           <div className="w-[500px]">
             <Calendar
               onSelectedDates={onSelectDateHandler}
+              unavailabeDates={selectUnabledDates}
               defaultStartDate={defaultStartDate}
               defaultEndDate={defaultEndDate}
             />

--- a/src/pages/trainer/TrainerHeader.tsx
+++ b/src/pages/trainer/TrainerHeader.tsx
@@ -6,7 +6,7 @@ const TrainerHeader = () => {
   const location = useLocation().pathname;
   let to = '/';
   let isNew = false;
-  if (location.startsWith('/trainer/new')) {
+  if (location.startsWith('/trainer/newTraining')) {
     isNew = true;
     to = '/';
   }

--- a/src/pages/trainer/TrainingForm.tsx
+++ b/src/pages/trainer/TrainingForm.tsx
@@ -12,7 +12,7 @@ import FormInput from '../../components/form/FormInput';
 import FormError from '../../components/form/FormError';
 import CheckBoxInput from '../../components/form/CheckboxInput';
 
-const TrainerForm: React.FC<{ dateList?: string[] }> = ({ dateList }) => {
+const TrainingForm: React.FC<{ dateList?: string[] }> = ({ dateList }) => {
   const errors = useActionData() as FormErrors;
   const [selectedDates, setSelectedDates] = useState<SelectedDates>({
     startDate: '',
@@ -43,7 +43,7 @@ const TrainerForm: React.FC<{ dateList?: string[] }> = ({ dateList }) => {
   return (
     <Form
       method="POST"
-      action="/trainer/new/create"
+      action="/trainer/newTraining"
       className="space-y-16 pb-6 pt-4"
       encType="multipart/form-data"
     >
@@ -83,7 +83,6 @@ const TrainerForm: React.FC<{ dateList?: string[] }> = ({ dateList }) => {
         <FormLabel htmlFor="categories">
           <h2 className="mb-4 text-3xl text-zinc-800">카테고리</h2>
           <CheckBoxInput options={options} />
-          {errors?.title && <FormError>{errors?.title}</FormError>}
         </FormLabel>
       </div>
       <div>
@@ -133,6 +132,7 @@ const TrainerForm: React.FC<{ dateList?: string[] }> = ({ dateList }) => {
         <FormLabel htmlFor="endHour">
           <TimeSelector inputName="lastHour" />
         </FormLabel>
+        {errors?.time && <FormError>{errors?.time}</FormError>}
       </div>
 
       <div>
@@ -148,4 +148,4 @@ const TrainerForm: React.FC<{ dateList?: string[] }> = ({ dateList }) => {
   );
 };
 
-export default TrainerForm;
+export default TrainingForm;

--- a/src/pages/trainer/create.tsx
+++ b/src/pages/trainer/create.tsx
@@ -105,13 +105,13 @@ export const action = async ({ request }: ActionFunctionArgs) => {
     const response = await createTraining(trainingObj);
 
     if (response && response.status === 200) {
-      return redirect('/');
+      return redirect('/trainer/home');
     }
   } catch (err) {
     const error = err as AxiosError<ErrorResponseDto>;
     errorFunc(error);
     if (error.response?.data.code === 'PERMISSION_DENIED') {
-      return redirect('/');
+      return redirect('/trainer/home');
     }
     return redirect('/trainer/newTraining');
   }

--- a/src/pages/trainer/create.tsx
+++ b/src/pages/trainer/create.tsx
@@ -6,7 +6,7 @@ import {
   useLoaderData,
 } from 'react-router-dom';
 import { AxiosError } from 'axios';
-import TrainerForm from './TrainerForm';
+import TrainingForm from './TrainingForm';
 import { FormErrors, LoaderData } from '../../types/common';
 import { createTraining, getTrainersDateList } from '../../apis/trainig';
 import { errorFunc } from '../../utils/util';
@@ -26,11 +26,11 @@ export const loader = (async () => {
   }
 }) satisfies LoaderFunction;
 
-const CreateTrainer = () => {
+const CreateTraining = () => {
   const res = useLoaderData() as LoaderData<typeof loader>;
   return (
     <div className="space-y-8">
-      <TrainerForm dateList={res?.data} />
+      <TrainingForm dateList={res?.data} />
     </div>
   );
 };
@@ -68,15 +68,20 @@ export const action = async ({ request }: ActionFunctionArgs) => {
   if (!content) errors.content = '내용을 입력해야 합니다.';
   if (images.length === 0) errors.images = '이미지를 업로드해야 합니다.';
   if (!price) errors.price = '가격을 입력해야 합니다.';
-  if (!startDate || !endDate || !startHour || !endHour) {
-    errors.dateTime = '날짜와 시간을 입력해야 합니다';
+  if (!startDate || !endDate) {
+    errors.dateTime = '날짜를 입력해야 합니다.';
+  }
+  if (!startHour || !endHour) {
+    errors.time = '시간을 입력해야 합니다.';
   }
 
   const startDateTime = new Date(`${startDate}T${startHour}`);
   const endDateTime = new Date(`${endDate}T${endHour}`);
   if (startDateTime >= endDateTime) {
-    errors.dateTime =
-      '시작 날짜 및 시간이 종료 날짜 및 시간보다 빨라야 합니다.';
+    errors.dateTime = '시작 날짜가 종료 날짜보다 빨라야 합니다.';
+  }
+  if (startHour >= endHour) {
+    errors.time = '종료 시간이 시작 시간보다 늦어야 합니다.';
   }
 
   if (Object.keys(errors).length > 0) {
@@ -108,9 +113,9 @@ export const action = async ({ request }: ActionFunctionArgs) => {
     if (error.response?.data.code === 'PERMISSION_DENIED') {
       return redirect('/');
     }
-    return redirect('/trainer/new/create');
+    return redirect('/trainer/newTraining');
   }
   return null;
 };
 
-export default CreateTrainer;
+export default CreateTraining;

--- a/src/pages/trainer/index.tsx
+++ b/src/pages/trainer/index.tsx
@@ -329,7 +329,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
 
       if (response && response.status === 200) {
         console.log('success');
-        return redirect('/');
+        return redirect('/trainer/home');
       }
     } catch (err) {
       const error = err as AxiosError<ErrorResponseDto>;
@@ -357,10 +357,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
       const res = await updateTrainingCalendar(Number(id), requestData);
       if (res.status === 200) {
         console.log('success');
-        return redirect('/');
-      }
-      if (res.status === 201) {
-        return redirect('/login');
+        return redirect('/trainer/home');
       }
       throw new Error(`server is trobule with${res.status}`);
     } catch (err) {

--- a/src/pages/trainer/index.tsx
+++ b/src/pages/trainer/index.tsx
@@ -224,7 +224,7 @@ const TrainerHome = () => {
         <div className="flex items-center justify-between">
           <h1 className="text-3xl font-bold">트레이닝</h1>
           <Link
-            to="/trainer/new"
+            to="/trainer/newTraining"
             className="shrink-0 rounded-full bg-slate-50 px-4 py-4"
           >
             트레이닝 생성하기
@@ -334,7 +334,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
     } catch (err) {
       const error = err as AxiosError<ErrorResponseDto>;
       errorFunc(error);
-      return redirect('/trainer/new/create');
+      return redirect('/trainer/newTraining');
     }
   } else if (type === 'calendar') {
     const startDate = formData.get('startDate') as string;

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -62,6 +62,7 @@ export interface FormErrors {
   quota?: string;
   price?: string;
   dateTime?: string;
+  time?: string;
 }
 
 export type LoaderData<TLoaderFn extends LoaderFunction> =


### PR DESCRIPTION
## 변경사항
[트레이닝 생성]
- 생성이 불가능한 날짜를 안 받아오는거 수정
- 제출 버튼 누르고 405에러로 트레이닝 생성이 안 됐었음. path 에러 수정
- 리다이렉트를 /trainer/home으로 변경

[트레이닝 수정]
- 날짜 수정 버튼 누르면 불가능한 날짜(다른 트레이닝이 있는 날짜)를 안 받아왔었음. 수정
- 수정 시 리다이렉트 /trainer/home으로 변경
